### PR TITLE
Run apt-get clean, and removed .bsp from +map

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Max Gonzih <gonzih at gmail dot com>
 RUN apt-get -y update
 RUN apt-get -y upgrade
 RUN apt-get -y install lib32gcc1 lib32z1 lib32ncurses5 lib32bz2-1.0 lib32asound2 wget
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN adduser --gecos "" tf2
 
 USER tf2
@@ -19,4 +20,4 @@ RUN $SERVER/update.sh
 EXPOSE 27015/udp
 
 ENTRYPOINT ["/home/tf2/hlserver/tf.sh"]
-CMD ["+sv_pure", "1", "+mapcycle", "mapcycle_quickplay_payload.txt", "+map", "pl_badwater.bsp", "+maxplayers", "24"]
+CMD ["+sv_pure", "1", "+mapcycle", "mapcycle_quickplay_payload.txt", "+map", "pl_badwater", "+maxplayers", "24"]


### PR DESCRIPTION
Removed .bsp from +map because it's not needed. Added apt-get clean, and cleared tmp folders from installation of libraries to remove unnecessary files for docker.
