### PR TITLE
Specify ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:12.04
 MAINTAINER Max Gonzih <gonzih at gmail dot com>
 
 RUN apt-get -y update


### PR DESCRIPTION
This pull request specifies the version of Ubuntu to be 12.04. This image doesn't work if the latest Ubuntu is used because the lib32asound2 package [was deleted in 13.10](https://launchpad.net/ubuntu/saucy/amd64/lib32asound2).
